### PR TITLE
Hex moved to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,9 @@ edition = "2018"
 
 [dependencies]
 nom="5"
-hex="0.4.0"
 chrono="0.4"
 ring="0.16.9"
 partial_application="0.2.0"
+
+[dev-dependencies]
+hex="0.4.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use hex;
+//use hex;
 use nom::number::complete::le_u32;
 use parse_bitcoin::parsers::parse_block;
 use parse_bitcoin::utils::find_block_start;


### PR DESCRIPTION
`hex` crate was used in tests only and in the commented code within
main. Since it wasn't needed in the proper code, it was moved to
dev-dependencies.