### PR TITLE
Use strong type for Network.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +155,7 @@ name = "parse_bitcoin"
 version = "0.1.0"
 dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "partial_application 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -383,6 +394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
+"checksum displaydoc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e6269d127174b18c665e683e23c2c55d3735fadbec4181c7c70b0450b764bfa5"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
 "checksum js-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)" = "367647c532db6f1555d7151e619540ec5f713328235b8c062c6b4f63e84adfe3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ hex="0.4.0"
 chrono="0.4"
 ring="0.16.9"
 partial_application="0.2.0"
+displaydoc = { version = "0.1.6", optional = true }

--- a/src/parsers/parse_magic_number.rs
+++ b/src/parsers/parse_magic_number.rs
@@ -1,13 +1,14 @@
 use nom::number::complete::le_u32;
 use nom::IResult;
+use crate::types::Network;
 
-pub fn parse_magic_number(input: &[u8]) -> IResult<&[u8], Option<&str>> {
+pub fn parse_magic_number(input: &[u8]) -> IResult<&[u8], Option<Network>> {
     let (i, o) = le_u32(input)?;
     let result = match o {
-        0xD9B4BEF9 => Some("mainnet"),
-        0xDAB5BFFA => Some("regtest"),
-        0x0709110B => Some("testnet"),
-        0xFEB4BEF9 => Some("namecoin"),
+        0xD9B4BEF9 => Some(Network::Mainnet),
+        0xDAB5BFFA => Some(Network::Regtest),
+        0x0709110B => Some(Network::Testnet),
+        0xFEB4BEF9 => Some(Network::Namecoin),
         _ => None,
     };
     Ok((i, result))
@@ -20,16 +21,16 @@ mod test {
     fn test_parse_magic_number() {
         let data = &[0xf9, 0xbe, 0xb4, 0xd9][..];
         let (_, chain) = parse_magic_number(data).unwrap();
-        assert_eq!(chain, Some("mainnet"));
+        assert_eq!(chain, Some(Network::Mainnet));
         let data = &[0xfa, 0xbf, 0xb5, 0xda][..];
         let (_, chain) = parse_magic_number(data).unwrap();
-        assert_eq!(chain, Some("regtest"));
+        assert_eq!(chain, Some(Network::Regtest));
         let data = &[0x0b, 0x11, 0x09, 0x07][..];
         let (_, chain) = parse_magic_number(data).unwrap();
-        assert_eq!(chain, Some("testnet"));
+        assert_eq!(chain, Some(Network::Testnet));
         let data = &[0xf9, 0xbe, 0xb4, 0xfe][..];
         let (_, chain) = parse_magic_number(data).unwrap();
-        assert_eq!(chain, Some("namecoin"));
+        assert_eq!(chain, Some(Network::Namecoin));
         let data = &[0xf9, 0xbe, 0xb4, 0xff][..];
         let (_, chain) = parse_magic_number(data).unwrap();
         assert_eq!(chain, None);

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -18,3 +18,5 @@ pub use self::transaction::Transaction;
 pub use self::transaction::TransactionBuilder;
 mod block;
 pub use self::block::Block;
+mod network;
+pub use network::Network;

--- a/src/types/network.rs
+++ b/src/types/network.rs
@@ -1,0 +1,17 @@
+/// Bitcoin/shitcoin network
+///
+/// This enum is `non_exhaustive` to allow adding new kinds of test or shitcoin networks in the
+/// future.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "displaydoc", derive(displaydoc::Display))]
+#[non_exhaustive]
+pub enum Network {
+    /// mainnet
+    Mainnet,
+    /// testnet
+    Testnet,
+    /// regtest
+    Regtest,
+    /// namecoin
+    Namecoin,
+}

--- a/src/utils/find_block_start.rs
+++ b/src/utils/find_block_start.rs
@@ -1,9 +1,10 @@
 use crate::parsers::parse_magic_number;
+use crate::types::Network;
 use nom::combinator::peek;
 use nom::number::complete::le_u8;
 use nom::IResult;
 
-pub fn find_block_start(mut input: &[u8]) -> IResult<&[u8], Option<&str>> {
+pub fn find_block_start(mut input: &[u8]) -> IResult<&[u8], Option<Network>> {
     //move per byte untill magic number is found
     loop {
         match peek(parse_magic_number)(input)?.1 {


### PR DESCRIPTION
The resulting type from parsing magic number was previously stringly
type. This is not considered idiomatic, as it comes with bunch of
problems: possible typos, decreased effiiency of comparison, lack of
static analysis...

This change introduces a new type called `Network` that implements a
bunch of standard traits for these kinds of types and this type is then
returned from parsing functions.