### PR TITLE
Added newtype for block time

### DIFF
--- a/src/parsers/parse_block_header.rs
+++ b/src/parsers/parse_block_header.rs
@@ -1,5 +1,5 @@
 use crate::{
-    types::{BlockHeader, BlockHeaderBuilder},
+    types::{BlockHeader, BlockHeaderBuilder, BlockTime},
     utils::hash256
 };
 use nom::{
@@ -26,7 +26,7 @@ pub fn parse_block_header(input: &[u8]) -> IResult<&[u8], BlockHeader> {
             .version(version)
             .prev_block_hash(prev_block_hash)
             .merkle_root_hash(merkle_root_hash)
-            .time(time)
+            .time(BlockTime(time))
             .bits(bits)
             .nonce(nonce)
             .hash(hash256(block_header_raw))
@@ -62,7 +62,7 @@ mod test {
                     .unwrap()
             )
         );
-        assert_eq!(header.time, 1576880064);
+        assert_eq!(header.time.0, 1576880064);
         assert_eq!(header.bits, Bytes::new(&hex::decode("d0bc1517").unwrap()));
         assert_eq!(header.nonce, Bytes::new(&hex::decode("6129429F").unwrap()));
         assert_eq!(
@@ -92,7 +92,7 @@ mod test {
                     .unwrap()
             )
         );
-        assert_eq!(header.time, 1576151029);
+        assert_eq!(header.time.0, 1576151029);
         assert_eq!(header.bits, Bytes::new(&hex::decode("d2db1517").unwrap()));
         assert_eq!(header.nonce, Bytes::new(&hex::decode("9AB9308D").unwrap()));
         assert_eq!(
@@ -122,7 +122,7 @@ mod test {
                     .unwrap()
             )
         );
-        assert_eq!(header.time, 1231006505);
+        assert_eq!(header.time.0, 1231006505);
         assert_eq!(header.bits, Bytes::new(&hex::decode("ffff001d").unwrap()));
         assert_eq!(header.nonce, Bytes::new(&hex::decode("1DAC2B7C").unwrap()));
         assert_eq!(

--- a/src/types/block_header.rs
+++ b/src/types/block_header.rs
@@ -1,5 +1,6 @@
 use crate::types::Bytes;
 use crate::types::Hash256;
+use crate::types::BlockTime;
 use chrono::prelude::*;
 use std::convert::TryInto;
 
@@ -8,8 +9,7 @@ pub struct BlockHeader {
     pub version: u32,
     pub prev_block_hash: Hash256,
     pub merkle_root_hash: Hash256,
-    pub time_str: String,
-    pub time: u32,
+    pub time: BlockTime,
     pub bits: Bytes,
     pub nonce: Bytes,
     pub hash: Hash256,
@@ -20,7 +20,7 @@ impl BlockHeader {
         v: u32,
         pbh: &[u8],
         mrh: &[u8],
-        t: u32,
+        t: BlockTime,
         b: &[u8],
         n: &[u8],
         h: Hash256,
@@ -30,9 +30,6 @@ impl BlockHeader {
             prev_block_hash: Hash256::new(pbh),
             merkle_root_hash: Hash256::new(mrh),
             time: t,
-            time_str: chrono::Utc
-                .timestamp(t.try_into().unwrap(), 0u32)
-                .to_rfc2822(),
             bits: Bytes::new(b),
             nonce: Bytes::new(n),
             hash: h,
@@ -46,8 +43,7 @@ impl std::default::Default for BlockHeader {
             version: 0,
             prev_block_hash: Hash256::default(),
             merkle_root_hash: Hash256::default(),
-            time_str: String::new(),
-            time: 0,
+            time: BlockTime(0),
             bits: Bytes::default(),
             nonce: Bytes::default(),
             hash: Hash256::default(),
@@ -77,13 +73,8 @@ impl BlockHeaderBuilder {
         self.blkh.merkle_root_hash = hash.into();
         self
     }
-    pub fn time(&mut self, time: u32) -> &mut Self {
+    pub fn time(&mut self, time: BlockTime) -> &mut Self {
         self.blkh.time = time;
-        self.blkh.time_str.push_str(
-            &chrono::Utc
-                .timestamp(time.try_into().unwrap(), 0u32)
-                .to_rfc2822(),
-        );
         self
     }
     pub fn bits<B: Into<Bytes>>(&mut self, bits: B) -> &mut Self {
@@ -103,7 +94,6 @@ impl BlockHeaderBuilder {
             version: self.blkh.version,
             prev_block_hash: self.blkh.prev_block_hash,
             merkle_root_hash: self.blkh.merkle_root_hash,
-            time_str: self.blkh.time_str.clone(),
             time: self.blkh.time,
             bits: self.blkh.bits.clone(),
             nonce: self.blkh.nonce.clone(),

--- a/src/types/block_time.rs
+++ b/src/types/block_time.rs
@@ -1,0 +1,21 @@
+use std::fmt;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct BlockTime(pub u32);
+
+impl From<BlockTime> for u32 {
+    fn from(value: BlockTime) -> Self {
+        value.0
+    }
+}
+
+impl fmt::Display for BlockTime {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use chrono::format::{Item, Fixed};
+        use chrono::offset::TimeZone;
+
+        fmt::Display::fmt(&chrono::Utc
+                .timestamp(i64::from(self.0), 0u32)
+                .format_with_items(std::iter::once(Item::Fixed(Fixed::RFC2822))), f)
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -5,6 +5,8 @@ pub use self::bytes::Bytes;
 mod block_header;
 pub use self::block_header::BlockHeader;
 pub use self::block_header::BlockHeaderBuilder;
+mod block_time;
+pub use block_time::BlockTime;
 mod tx_input;
 pub use self::tx_input::TxInput;
 pub use self::tx_input::TxInputBuilder;


### PR DESCRIPTION
This change adds a newtype for block time to improve robustness. Apart
from getting the advantages of strong type, this also removes the need
for storing the time in stringly form in the header, as it impls
Display. Finally, the Display implementation is more efficinet by not
allocating and clearer by using infallible conversion instead of
unwrapping.